### PR TITLE
Add `rz-ghidra` and `jsdec` decompilers

### DIFF
--- a/re.rizin.cutter.yml
+++ b/re.rizin.cutter.yml
@@ -68,6 +68,34 @@ modules:
         url: https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/6.0.2/graphviz-6.0.2.tar.gz
         sha256: 4dccb9399080b7572570fa11b236c0305370bac569be7d121d66196409d76705
 
+  - name: rz-ghidra
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_INSTALL_PREFIX=~/.local
+      - -DBUILD_CUTTER_PLUGIN=ON
+    sources:
+      - type: git
+        url: https://github.com/rizinorg/rz-ghidra.git
+        tag: rz-0.5.0
+        commit: 1ed04d6c29b1a8226f0c0cdf8163def4b2fb0b1e
+        x-checker-data:
+          type: git
+          tag-pattern: ^rz-([\d.]+)$
+
+  - name: jsdec
+    buildsystem: meson
+    config-opts:
+      - -Djsc_folder=".."
+      - --prefix=~/.local
+    sources:
+      - type: git
+        url: https://github.com/rizinorg/jsdec.git
+        tag: v0.5.0
+        commit: 8a4f4c852c918e8831a35ca18f09e028b86f91cf
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
+
   - name: cutter
     buildsystem: cmake-ninja
     builddir: true


### PR DESCRIPTION
The Cutter flatpak does not ship with a decompiler, which will force users to use another tool for decompilation.

Also include the ability for [flatpak-external-data-checker](https://github.com/flathub/flatpak-external-data-checker) to auto-generate PRs when new tags are released.

> Flathub runs this tool hourly for all Flatpak repos under [github.com/flathub](https://github.com/flathub). So, for those repos to receive update PRs, add x-checker-data [as needed to sources](https://github.com/flathub/flatpak-external-data-checker#changes-to-flatpak-manifests). Note Flathub's hosted tool only checks the default branch.